### PR TITLE
fix minor bugs

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,6 @@
 class AdminController < ApplicationController
+  before_action :ensure_logged_in, only: [:dashboard]
+
     def login
         # Handle the login logic for students here.
       end
@@ -8,6 +10,7 @@ class AdminController < ApplicationController
         # Authentication successful. Store user information in the session.
         session[:email] = @admin.email_id
         session[:name] = @admin.first_name
+        session[:admin_id] = @admin.id
         redirect_to admin_dashboard_path # Redirect to the admin's dashboard.
       else
         # Authentication failed. Show an error message and render the login form again.
@@ -20,5 +23,16 @@ class AdminController < ApplicationController
       session[:email] = nil  # Clear the student's session
       session[:name] = nil
       redirect_to admin_login_path  # Redirect to the root page or login page
+    end
+
+    def current_admin
+      @current_admin ||= Admin.find(session[:admin_id]) if session[:admin_id]
+    end
+
+    def ensure_logged_in
+      unless current_admin
+        flash[:alert] = "Please log in to continue."
+        redirect_to admin_login_path
+      end
     end
 end

--- a/app/controllers/faculty_controller.rb
+++ b/app/controllers/faculty_controller.rb
@@ -53,8 +53,22 @@ class FacultyController < ApplicationController
       if @documents.empty?
         @no_documents_message = 'This student has not submitted any documents.'
       else
-        @resume_url = @documents.first.resume_link
-        @report_url = @documents.first.report_link
+        # Parse the S3 URI to extract bucket name and object key
+        uri = URI.parse(@documents.first.resume_link)
+        bucket_name = uri.host
+        object_key = uri.path[1..-1] # Remove the leading '/'
+
+        # Generate a presigned URL that expires in 1 week
+        resp = Aws::S3::Client.new
+        presigner = Aws::S3::Presigner.new(client: resp)
+        @resume_url = presigner.presigned_url(:get_object,bucket: bucket_name, key: object_key, expires_in: 604800)
+        
+        # Parse the S3 URI to extract bucket name and object key
+        uri = URI.parse(@documents.first.report_link)
+        bucket_name = uri.host
+        object_key = uri.path[1..-1] # Remove the leading '/'
+        @report_url = presigner.presigned_url(:get_object,bucket: bucket_name, key: object_key, expires_in: 604800)
+       
         @private_comments = Assessment.where(student_id: @student.id).where.not(faculty_id: current_faculty.id)
       end
     end

--- a/app/controllers/student_documents_controller.rb
+++ b/app/controllers/student_documents_controller.rb
@@ -66,14 +66,10 @@ class StudentDocumentsController < ApplicationController
           obj.put_object(body: file,  content_type: 'application/pdf', key:input_string_resume )
         end
         
-        #get the url of uploaded resume from s3 bucket
-        resp = Aws::S3::Client.new
-        bucket_name = 'phd-annual-review-sys-docs'
-        presigner = Aws::S3::Presigner.new(client: resp)
-        presigned_url_resume = presigner.presigned_url(:get_object,bucket: bucket_name, key: input_string_resume, expires_in: 604800)
-        
+        #get the uri of uploaded resume from s3 bucket
+        resume_uri = 's3://'+ 'phd-annual-review-sys-docs/' + input_string_resume
         #update the resume_link column with link to the resume file
-        @student_document.update(resume_link: presigned_url_resume)
+        @student_document.update(resume_link: resume_uri)
       end
 
       if params[:student_document][:report_file].present?
@@ -91,14 +87,9 @@ class StudentDocumentsController < ApplicationController
           obj.put_object(body: file,  content_type: 'application/pdf', key:input_string_report )
         end
 
-        #get the url of uploaded report from s3 bucket
-        resp = Aws::S3::Client.new
-        bucket_name = 'phd-annual-review-sys-docs'
-        presigner = Aws::S3::Presigner.new(client: resp)
-        presigned_url_report = presigner.presigned_url(:get_object,bucket: bucket_name, key: input_string_report, expires_in: 604800)
-        
+        report_uri = 's3://'+ 'phd-annual-review-sys-docs/' + input_string_report
         #update the report_link column with link to the report file
-        @student_document.update(report_link: presigned_url_report)
+        @student_document.update(report_link: report_uri)
       end
 
         #update other columns

--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -35,7 +35,7 @@
           <%= student.last_name%>
         </td>
         <td>
-          <% if student.student_document.exists? %>
+          <% if StudentDocument.find_by(email_id: student.email_id) %>
             <!-- Check mark symbol if student_document is present -->
             <span>&#10004;</span>
           <% else %>


### PR DESCRIPTION
Admin dashboard is now only accessible after logging in as an admin
Ready for Review column in admin dashboard checks if the student has a corresponding document object
For the S3 bug, instead of storing the presigned URL in the db, now it stores the s3 object uri. The presigned URL is generated at the time the faculty goes to see the student documents. The URL will not expire when the faculty members go to review the student.